### PR TITLE
Install make instead of build-essentials

### DIFF
--- a/playbooks/make-install.yml
+++ b/playbooks/make-install.yml
@@ -1,7 +1,7 @@
 - name: Install build-essentials
   remote_user: ubuntu
   apt:
-    name: build-essentials
+    name: make
     state: present
     update_cache: yes
   tags:


### PR DESCRIPTION
build-essentials doesnt seem to exist in apt repository, and I probably dont need it