### PR TITLE
Run with privileged access when validating that certificates are in place

### DIFF
--- a/playbooks/configure-proxy.yml
+++ b/playbooks/configure-proxy.yml
@@ -23,9 +23,11 @@
 
 - name: Validate HTTPS certificates
   remote_user: ubuntu
-  become_user: root # Needed to read certs in /etc/letsencrypt/live/*
+  become_user: ubuntu
   block:
     - name: Validate certs
+      become_user: root
+      become: yes # Needed to read certs in /etc/letsencrypt/live/*
       make:
         chdir: /tmp/frontman
         target: validate-certs


### PR DESCRIPTION
The `/etc/letsencrypt/live/*`-folder is currently created so that it's only accessible by root. Thus, the ubuntu account can't see the content without using `sudo`. To do this with ansible, I need to set `become: yes`.

See: https://docs.ansible.com/ansible/2.4/become.html