### PR TITLE
Run as privileged user when removing frontman dir

### DIFF
--- a/playbooks/configure-proxy.yml
+++ b/playbooks/configure-proxy.yml
@@ -27,6 +27,7 @@
   become_user: ubuntu
   block:
     - name: Validate certs
+      become_user: root
       become: yes # Needed to read certs in /etc/letsencrypt/live/*
       make:
         chdir: /tmp/frontman


### PR DESCRIPTION
Currently one file in __py_cache__ is only writable by root