### PR TITLE
Only define remote_user in main playbook

### DIFF
--- a/playbooks/configure-proxy.yml
+++ b/playbooks/configure-proxy.yml
@@ -1,9 +1,7 @@
 - name: Setup frontman
-  remote_user: ubuntu
-  become_user: ubuntu
   block:
     - name: Remove existing dir
-      become: yes
+      become: yes # Needed to remove file in __py_cache__ writable by root
       file:
         state: absent
         path: /tmp/frontman
@@ -23,11 +21,8 @@
         mode: u=r,g=r,o=r
 
 - name: Validate HTTPS certificates
-  remote_user: ubuntu
-  become_user: ubuntu
   block:
     - name: Validate certs
-      become_user: root
       become: yes # Needed to read certs in /etc/letsencrypt/live/*
       make:
         chdir: /tmp/frontman
@@ -49,8 +44,6 @@
         target: start
 
 - name: Schedule certificate renewal
-  remote_user: ubuntu
-  become_user: ubuntu
   cron:
     name: renew-certs
     user: ubuntu

--- a/playbooks/docker-install.yml
+++ b/playbooks/docker-install.yml
@@ -1,7 +1,5 @@
 - name: Install docker
-  remote_user: ubuntu
   become: yes
-  become_user: root
   block:
     - name: Install docker packages
       apt:

--- a/playbooks/main.yml
+++ b/playbooks/main.yml
@@ -1,5 +1,6 @@
 - hosts: all
   gather_facts: false
+  remote_user: ubuntu
   tasks:
     - import_tasks: docker-install.yml
     - import_tasks: make-install.yml

--- a/playbooks/make-install.yml
+++ b/playbooks/make-install.yml
@@ -1,7 +1,5 @@
 - name: Install make
-  remote_user: ubuntu
   become: yes
-  become_user: root
   apt:
     name: make
     state: present


### PR DESCRIPTION
Also remove become_user and let it default to 'root'. This is because files created in docker containers currently only will have permissions set for root. I need to be able to access these (e.g. for validating that certificates exist in /etc/letsencrypt/live/*).