### PR TITLE
Verify that machine isn't manager node prior to init swarm

### DIFF
--- a/playbooks/docker-install.yml
+++ b/playbooks/docker-install.yml
@@ -65,7 +65,7 @@
 - name: Initialize single node swarm
   block:
     - name: Validate that server is manager node
-      shell: 'test $(docker info --format "{{\.Swarm\.ControlAvailable}}") = true'
+      shell: test $(docker info --format \{\{'.Swarm.ControlAvailable'\}\}) = true
   rescue:
     - name: Initialize single node swarm
       command: docker swarm init

--- a/playbooks/docker-install.yml
+++ b/playbooks/docker-install.yml
@@ -65,7 +65,7 @@
 - name: Initialize single node swarm
   block:
     - name: Validate that server is manager node
-      command: test $(docker info --format '{{.Swarm.ControlAvailable}}') = true
+      command: test $(docker info --format '{{\.Swarm\.ControlAvailable}}') = true
   rescue:
     - name: Initialize single node swarm
       command: docker swarm init

--- a/playbooks/docker-install.yml
+++ b/playbooks/docker-install.yml
@@ -65,8 +65,7 @@
 - name: Initialize single node swarm
   block:
     - name: Validate that server is manager node
-      shell: >
-        test $(docker info --format "{{.Swarm.ControlAvailable}}") = true
+      shell: "test $(docker info --format \"{{.Swarm.ControlAvailable}}\") = true"
   rescue:
     - name: Initialize single node swarm
       command: docker swarm init

--- a/playbooks/docker-install.yml
+++ b/playbooks/docker-install.yml
@@ -65,7 +65,7 @@
     - name: Initialize single node swarm
       shell:
         cmd: |
-          if [ "$(docker info --format '{{.Swarm.ControlAvailable}}')" != "active" ];
+          if [ "$(docker info --format '{{.Swarm.ControlAvailable}}')" == "false" ];
           then
             docker swarm init;
           fi

--- a/playbooks/docker-install.yml
+++ b/playbooks/docker-install.yml
@@ -65,7 +65,8 @@
 - name: Initialize single node swarm
   block:
     - name: Validate that server is manager node
-      command: test $(docker info --format '{{\.Swarm\.ControlAvailable}}') = true
+      shell: >
+        test $(docker info --format "{{.Swarm.ControlAvailable}}") = true
   rescue:
     - name: Initialize single node swarm
       command: docker swarm init

--- a/playbooks/docker-install.yml
+++ b/playbooks/docker-install.yml
@@ -65,7 +65,7 @@
 - name: Initialize single node swarm
   block:
     - name: Validate that server is manager node
-      command: test "$(docker info --format '{{.Swarm.ControlAvailable}}')" = "true"
+      command: test $(docker info --format '{{.Swarm.ControlAvailable}}') = true
   rescue:
     - name: Initialize single node swarm
       command: docker swarm init

--- a/playbooks/docker-install.yml
+++ b/playbooks/docker-install.yml
@@ -65,7 +65,7 @@
 - name: Initialize single node swarm
   block:
     - name: Validate that server is manager node
-      shell: 'test $(docker info --format "{{.Swarm.ControlAvailable}}") = true'
+      shell: 'test $(docker info --format "{{\.Swarm\.ControlAvailable}}") = true'
   rescue:
     - name: Initialize single node swarm
       command: docker swarm init

--- a/playbooks/docker-install.yml
+++ b/playbooks/docker-install.yml
@@ -65,7 +65,7 @@
     - name: Initialize single node swarm
       shell:
         cmd: |
-          if [ "$(docker info --format '{{.Swarm.ControlAvailable}}')" != "active" ]
+          if [ "$(docker info --format '{{.Swarm.ControlAvailable}}')" != "active" ];
           then
-            docker swarm init
+            docker swarm init;
           fi

--- a/playbooks/docker-install.yml
+++ b/playbooks/docker-install.yml
@@ -64,4 +64,8 @@
         force: true
     - name: Initialize single node swarm
       shell:
-        cmd: docker swarm init
+        cmd: |
+          if [ "$(docker info --format '{{.Swarm.ControlAvailable}}')" != "active" ]
+          then
+            docker swarm init
+          fi

--- a/playbooks/docker-install.yml
+++ b/playbooks/docker-install.yml
@@ -65,7 +65,7 @@
 - name: Initialize single node swarm
   block:
     - name: Validate that server is manager node
-      shell: "test $(docker info --format \"{{.Swarm.ControlAvailable}}\") = true"
+      shell: 'test $(docker info --format "{{.Swarm.ControlAvailable}}") = true'
   rescue:
     - name: Initialize single node swarm
       command: docker swarm init

--- a/playbooks/docker-install.yml
+++ b/playbooks/docker-install.yml
@@ -62,10 +62,10 @@
         group: docker
         mode: 'u+x,g+x'
         force: true
+- name: Initialize single node swarm
+  block:
+    - name: Validate that server is manager node
+      command: test "$(docker info --format '{{.Swarm.ControlAvailable}}')" = "true"
+  rescue:
     - name: Initialize single node swarm
-      shell:
-        cmd: |
-          if [ "$(docker info --format '{{.Swarm.ControlAvailable}}')" == "false" ];
-          then
-            docker swarm init;
-          fi
+      command: docker swarm init


### PR DESCRIPTION
Escaping of '{' and '}' is required because jinja is trying to parse them. See: https://github.com/ansible/ansible/issues/21304