### PR TITLE
Set default address range for swarm

### DIFF
--- a/playbooks/docker-install.yml
+++ b/playbooks/docker-install.yml
@@ -54,4 +54,4 @@
       shell: test $(docker info --format \{\{'.Swarm.ControlAvailable'\}\}) = true
   rescue:
     - name: Initialize single node swarm
-      command: docker swarm init
+      command: docker swarm init --default-addr-pool 192.168.0.0/16 ## Default range may conflict with ec2 dns


### PR DESCRIPTION
It seems like default address range may conflict with default DNS server used on the EC2. Noticed by that I'm not able to resolve any external DNS lookups from a specific docker service. See https://stackoverflow.com/questions/51404544/docker-containers-in-stacks-within-ec2-instance-do-not-inherit-dns-nameserver.